### PR TITLE
openlist2: add fuse as build depends

### DIFF
--- a/openlist2/Makefile
+++ b/openlist2/Makefile
@@ -27,7 +27,7 @@ define Download/openlist-frontend
   HASH:=508c5d13bdf9defae749bf10b29353016aa45394fb99af78788fd59805a4ead0
 endef
 
-PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_DEPENDS:=golang/host fuse
 PKG_BUILD_PARALLEL:=1
 PKG_USE_MIPS16:=0
 PKG_BUILD_FLAGS:=no-mips16


### PR DESCRIPTION
Fix error:
```
2025-08-01T03:56:47.0001550Z github.com/winfsp/cgofuse/fuse
2025-08-01T03:56:47.0422793Z # github.com/winfsp/cgofuse/fuse
2025-08-01T03:56:47.0423829Z /builder/dl/go-mod-cache/github.com/winfsp/cgofuse@v1.6.0/fuse/host_cgo.go:119:10: fatal error: fuse.h: No such file or directory
2025-08-01T03:56:47.0424774Z   119 | #include <fuse.h>
2025-08-01T03:56:47.0425111Z       |          ^~~~~~~~
2025-08-01T03:56:47.0425439Z compilation terminated.
```